### PR TITLE
Change WhiteK11 to be a black square.

### DIFF
--- a/3D Chess/Assets/Scripts/InSceneManager/ChessBoard3D.cs
+++ b/3D Chess/Assets/Scripts/InSceneManager/ChessBoard3D.cs
@@ -73,7 +73,7 @@ public class ChessBoard3D : MonoBehaviour
 
 		this.size = chessBoardProperties.size = size;
 		chessBoardProperties.locWhiteK11sq = locWhiteK11sq;
-		bool firstSqIsWhite = locWhiteK11sq.z % 2 == 0;
+		bool firstSqIsWhite = locWhiteK11sq.z % 2 == 1; // Convention is false, first square is black.
 
 		chessBoardProperties.ComputeBoardEdges();
 


### PR DESCRIPTION
On the 8x8x8 board (default) White's King Rook will be on a white square, his King will be on a black square, so both Queens will be on white squares, and the first square of the board (White's Queen Rook) will be on a black square. Note that on the 10 level boards, the color of the Rook squares will be swapped.