### PR TITLE
Establish solid src/dst square interface

### DIFF
--- a/3D Chess/Assets/Scripts/InSceneManager/AdvancementSquare.cs
+++ b/3D Chess/Assets/Scripts/InSceneManager/AdvancementSquare.cs
@@ -12,12 +12,29 @@ using System;
 //	 Rect: 5, 9, 13, 17 ...
 // Uses Strategy pattern to abstract differences between the 3 base pieces: Rook, Bishop, & Duke, and quadrant versus linear moves.
 
+public enum MetaSet
+{
+	Identical,
+	SuperSet,
+	SubSet,
+	ShiftSet,
+	Different,
+	Null,
+}
+
 // Base class.
 public class AdvancementSquare
 {
 	public int Perims { get; set; } // Is perimeters.Count, but avoids coupling API to List implementation.
 
 	public List<Vector3Int[]> perimeters; // Populated by daughter ctors. TODO: add First/Next/Last/Prev methods to complete decoupling.
+
+	public bool locked;
+
+	static public MetaSet AreAdSqsMetaSet(AdvancementSquare first, AdvancementSquare second)
+	{
+		return MetaSet.Different;
+	}
 
 	protected Vector3Int nullSquare = new Vector3Int(-1, -1, -1); // TODO: remove dup nullSquare, move up.
 }


### PR DESCRIPTION
Symmetric use of dst & src squares to manage advancement square presentation.
Toggle clears, clicking on the other or off board locks the advancement square.
Changing dst square can expand or contract existing advancement square.
Changing src square can grow, shrink, or shift existing advancement square.
Changing either will clear existing (if not locked) and present new advancement square.